### PR TITLE
RAINCATCH-539 - Renaming fileService to FileClient

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 module.exports = {
   FILE_MODULE_ID: "wfm.file",
   FILE_DIRECTIVE_MODULE:"wfm.file.directives",
+  FILE_SERVICE_MODULE:"wfm.file.service",
   FILES_ENTITY_NAME: "files",
   FILE: "file",
   TOPIC_PREFIX: "wfm",

--- a/lib/service.js
+++ b/lib/service.js
@@ -2,14 +2,14 @@
 
 var _ = require('lodash');
 var CONSTANTS = require('./constants');
-var fileClient = require('./file-client');
+var FileClient = require('./file-client');
 
-module.exports = CONSTANTS.FILE_MODULE_ID;
+module.exports = CONSTANTS.FILE_SERVICE_MODULE;
 
-angular.module(CONSTANTS.FILE_MODULE_ID, [])
-  .factory('fileService', function($q, $timeout, mediator){
+angular.module(CONSTANTS.FILE_SERVICE_MODULE, [])
+  .factory('fileClient', function($q, $timeout, mediator){
     var fileService = {};
-    var fileClient = fileClient(mediator);
+    var fileClient = FileClient(mediator);
     _.forOwn(fileClient, function(value, key){
       if(typeof value === 'function'){
         fileService[key] = function(){
@@ -19,21 +19,5 @@ angular.module(CONSTANTS.FILE_MODULE_ID, [])
         fileService[key] = value;
       }
     });
-    fileService.createManager = function() {
-      if (fileService.manager) {
-        return fileService.manager;
-      } else {
-        fileService.manager = fileClient;
-        return fileService.manager;
-      }
-    };
-    fileService.removeManager = function() {
-      if(fileService.manager){
-        return fileService.manager.safeStop()
-          .then(function(){
-            delete fileService.manager;
-          });
-      }
-    };
     return fileService;
   });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {"name": "fh-wfm-file-angular",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Angular 1 implementation for a WFM module providing file support",
   "main": "lib/file-ng.js",
   "repository": {


### PR DESCRIPTION
# Motivation

Rename service name from `FileService` to `FileClient` to align with other services.
Removing unused code. 
Extracting service name to constants.

ping @witmicko @nialldonnellyfh 